### PR TITLE
Simplify plugins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ You'll need Docker desktop for your platform installed to run the project in loc
 
 * Composer will have already created a `.env` file in the `cms/` directory, based off of the provided `example.env`
   
-* Edit the `cms/composer.json` file and change the line `"url": "/Users/andrew/webdev/craft/*",` in `repostories` to point to your local plugin Git repositories
-* Edit the `docker-composer.yaml` file and change the line `- /Users/andrew/webdev/craft:/Users/andrew/webdev/craft` to point to your local plugin Git repositories
+* Edit the `docker-composer.yaml` file and change the line `- /Users/andrew/webdev/craft:/plugins` to point to your local plugin Git repositories
 * Start up the site with `make dev` (the first build will be somewhat lengthy)
 * Navigate to `http://localhost:8000` to use the site
 

--- a/cms/composer.json
+++ b/cms/composer.json
@@ -51,7 +51,7 @@
   "repositories": [
     {
       "type": "path",
-      "url": "/Users/andrew/webdev/craft/*",
+      "url": "/plugins/*",
       "options": {
         "symlink": true
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     init: true
     volumes: &php-volumes
     # Change the path below to map to your local plugin repositories
-      - /Users/andrew/webdev/craft:/Users/andrew/webdev/craft
+      - /Users/andrew/webdev/craft:/plugins
       - cpresources:/var/www/project/cms/web/cpresources:delegated
       - storage:/var/www/project/cms/storage:delegated
       - ./cms/storage/logs:/var/www/project/cms/storage/logs:delegated


### PR DESCRIPTION
### Description

No need to mirror the host path inside Docker for the plugins path - can simplify down to /plugins and be able to lose a little bit of complexity from the initial setup, and not even have to touch composer.json (until the user at least is adding in their own individual plugin mappings).
