### PR TITLE
Added WORKDIR

### DIFF
--- a/docker-config/php-dev-craft/Dockerfile
+++ b/docker-config/php-dev-craft/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
         && \
         npm install -g puppeteer
 
+WORKDIR /var/www/project
+
 # Force the permissions to be set properly
 RUN chown -R www-data:www-data /var/www/project
 


### PR DESCRIPTION
Without this, the dev container fails on `docker-compose up`.

<img width="1062" alt="Screenshot 2022-03-27 at 08 56 25" src="https://user-images.githubusercontent.com/57572400/160272569-892e457b-e26f-4564-8b31-02070aa0ce91.png">
