### PR TITLE
General config setting overrides

### DIFF
--- a/cms_v3/config/general.php
+++ b/cms_v3/config/general.php
@@ -43,4 +43,6 @@ return [
     'useEmailAsUsername' => false,
     'usePathInfo' => true,
     'useProjectConfigFile' => true,
+    'requireMatchingUserAgentForSession' => false,
+    'rememberedUserSessionDuration' => 31536000,
 ];

--- a/cms_v4/config/general.php
+++ b/cms_v4/config/general.php
@@ -42,4 +42,6 @@ return [
     'omitScriptNameInUrls' => true,
     'useEmailAsUsername' => false,
     'usePathInfo' => true,
+    'requireMatchingUserAgentForSession' => false,
+    'rememberedUserSessionDuration' => 31536000,
 ];


### PR DESCRIPTION
Adds general config setting overrides to prevent being logged out when the user agent changes (after a browser version update, for example) and to extend remembered user session durations to 1 year.