### PR TITLE
Add `down` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ up:
 		done ; \
 		docker-compose up ; \
     fi
-down: docker-compose down
+down: 
+	docker-compose down
 %:
 	@:
 # ref: https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ up:
 		done ; \
 		docker-compose up ; \
     fi
+down: docker-compose down
 %:
 	@:
 # ref: https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line


### PR DESCRIPTION
This PR adds a `down` command, for completion. Why? Sometimes a terminal connection is closed, in which case `CMD+C` is no longer an option, so `make down` is simple shorthand for `docker-compose down` and a natural companion to `make up`.