### PR TITLE
Remove `optimize-autoloader`

### DIFF
--- a/cms_v3/composer.json
+++ b/cms_v3/composer.json
@@ -69,7 +69,6 @@
       "craftcms/plugin-installer": true,
       "yiisoft/yii2-composer": true
     },
-    "optimize-autoloader": true,
     "sort-packages": true
   },
   "repositories": [

--- a/cms_v4/composer.json
+++ b/cms_v4/composer.json
@@ -66,7 +66,6 @@
       "craftcms/plugin-installer": true,
       "yiisoft/yii2-composer": true
     },
-    "optimize-autoloader": true,
     "sort-packages": true
   },
   "repositories": [


### PR DESCRIPTION
This PR removes the `optimize-autoloader` config option from the `composer.json` files, since according to the Composer docs:

> By default, the Composer autoloader runs relatively fast. However, due to the way PSR-4 and PSR-0 autoloading rules are set up, it needs to check the filesystem before resolving a classname conclusively. This slows things down quite a bit, but it is convenient in development environments because when you add a new class it can immediately be discovered/used without having to rebuild the autoloader configuration.

And:

> You should not enable any of these optimizations in development as they all will cause various problems when adding/removing classes. The performance gains are not worth the trouble in a development setting.

Source: https://getcomposer.org/doc/articles/autoloader-optimization.md#autoloader-optimization

Related discussion: https://github.com/craftcms/cms/discussions/12583